### PR TITLE
html/app: Add support for ?search={URI}

### DIFF
--- a/html/app.jsx
+++ b/html/app.jsx
@@ -154,6 +154,7 @@ class SearchForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      querySearch: '',
       searchInput: '',
       messages: [],
       appName: null,
@@ -182,14 +183,19 @@ class SearchForm extends React.Component {
       return;
     }
 
+    search(this.state.searchInput);
+  }
+
+  search(input) {
+    handleSearchInput(input);
     try {
-      this.state.messages = []
+      this.state.messages = [];
       this.state.ws.send(JSON.stringify({
         'action': 'new',
-        'message': this.state.searchInput
-      }))
+        'message': input,
+      }));
     } catch (error) {
-      console.log(error)
+      console.log(error);
     }
   }
 
@@ -304,13 +310,23 @@ class SearchForm extends React.Component {
     let messages;
     let searchClass;
     if(this.state.appName != null) {
-        messages =
-          <Status messages={this.state.messages} />
-        searchClass = null
+      messages =
+        <Status messages={this.state.messages} />
+      searchClass = null;
     } else {
-        messages = []
-        searchClass = 'search-center'
+      messages = [];
+      searchClass = 'search-center';
+      if (!this.state.searchInput) {
+        let params = (new URL(window.location)).searchParams;
+        let searchInput = params.get('search');
+        if (searchInput && searchInput != this.state.querySearch) {
+          this.state.querySearch = searchInput;
+          search(searchInput);
+        }
+      }
+
     }
+
     return (
       <div className={searchClass}>
         <h3>PromeCIeus</h3>


### PR DESCRIPTION
This allows folks to link to PromeCIeus with a particular job-detail page in mind, and folks clicking through won't have to bother pasting in the URI or clicking "Generate".  For example, the job-detail page itself may want to link PromeCIeus with it's own location in the search query parameter.

Calling `handleSearchInput` from the new `search()` function means that folks typing into the form field and then clicking "Generate" will get `handleSearchInput` called twice, which is not a big deal.  And it means that folks calling `search()` from other places can't forget to set the state.

The new `querySearch` state ensures we only trigger the auto-search logic when the query value changes.

`searchParams()` business is based on [the MDN docs][1].

[1]: https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams#Example