### PR TITLE
Support direct tarball links copied from gcsweb

### DIFF
--- a/pkg/promecieus/helpers.go
+++ b/pkg/promecieus/helpers.go
@@ -136,7 +136,9 @@ func getTarURLFromProw(conn *websocket.Conn, baseURL string) (ProwInfo, error) {
 
 	// Is it a direct prom tarball link?
 	if strings.HasSuffix(baseURL, promTarPath) {
-		prowInfo.MetricsURL = baseURL
+		// Make it a fetchable URL if it's a gcsweb URL
+		tempMetricsURL := strings.Replace(baseURL, gcsPrefix+"/gcs", storagePrefix, -1)
+		prowInfo.MetricsURL = tempMetricsURL
 		// there is no way to find out the time via direct tarball link, use current time
 		prowInfo.Finished = time.Now()
 		prowInfo.Started = time.Now()


### PR DESCRIPTION
As per title, this supports copying a link from gcsweb into promecieus and enable it to still work.