### PR TITLE
helpers: remove ensure func

### DIFF
--- a/pkg/promecieus/helpers.go
+++ b/pkg/promecieus/helpers.go
@@ -78,28 +78,9 @@ func getLinksFromURL(url string) ([]string, error) {
 	}
 }
 
-func ensureMetricsURL(url *url.URL) (int, error) {
-	if url == nil {
-		return 0, fmt.Errorf("url was nil")
-	}
-	var netClient = &http.Client{
-		Timeout: time.Second * 10,
-	}
-	resp, err := netClient.Head(url.String())
-	if resp == nil {
-		return 0, err
-	}
-	return resp.StatusCode, err
-}
-
 func getMetricsTar(conn *websocket.Conn, url *url.URL) (ProwInfo, error) {
 	sendWSMessage(conn, "status", fmt.Sprintf("Fetching %s", url))
-	// Ensure initial URL is valid
-	statusCode, err := ensureMetricsURL(url)
-	if err != nil || statusCode != http.StatusOK {
-		return ProwInfo{}, fmt.Errorf("failed to fetch url %s: code %d, %s", url, statusCode, err)
-	}
-
+	
 	prowInfo, err := getTarURLFromProw(conn, url)
 	if err != nil {
 		return prowInfo, err


### PR DESCRIPTION
This was originally supposed to be a super-quick fail-fast for bad input, but a) it's touching a Deck/Prow URL which may be super slow to load and entirely not necessary for the actual functionality and b) for direct tar links, the HEAD is rejected by the bucket. We parse the URL directly after this, in `getTarURLFromProw()`, and we will still fail very quickly so it seems reasonable to remove this HEAD as superfluous.